### PR TITLE
Disable parallel gradle execution in build&test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,10 +32,11 @@ jobs:
         # there is some race condition in gradle build, which makes gradle never terminate in ~30% of the runs
         # running build first without datahub-web-react:yarnBuild and then with it is 100% stable
         # datahub-frontend:unzipAssets depends on datahub-web-react:yarnBuild but gradle does not know about it
-        # NOTE: --max-workers=2 is here because of an issue where a github worker kept disappearing towards the end of the build
+        # NOTE: --no-parallel is here because of an issue where a github worker kept disappearing towards the end of the build
+        #       If you think it's a solved issue - please remove this flag
         run: |
-          ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x datahub-web-react:yarnBuild -x datahub-frontend:unzipAssets --max-workers=2
-          ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x :metadata-integration:java:spark-lineage:test --max-workers=2
+          ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x datahub-web-react:yarnBuild -x datahub-frontend:unzipAssets --no-parallel
+          ./gradlew build -x :metadata-ingestion:build -x :metadata-ingestion:check -x docs-website:build -x :metadata-integration:java:spark-lineage:test --no-parallel
       - uses: actions/upload-artifact@v2
         if: always()
         with:


### PR DESCRIPTION
This is a second attempt to fix an issue where github worker disappears while running the tests.