### PR TITLE
Try running build and test on MacOS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

```
Hardware specification for Windows and Linux virtual machines:

2-core CPU
7 GB of RAM memory
14 GB of SSD disk space

Hardware specification for macOS virtual machines:

3-core CPU
14 GB of RAM memory
14 GB of SSD disk space
```